### PR TITLE
Adjusts breakpoint for smartphone resolution

### DIFF
--- a/scss/lib/_variable.scss
+++ b/scss/lib/_variable.scss
@@ -62,7 +62,7 @@ $code-copy-success-bg: #4aaa50;
 $code-copy-failed-bg: #c44336;
 
 // Media Queries
-$mq-xs: "(max-width: 480px)";
-$mq-sm: "(min-width: 768px)";
-$mq-md: "(min-width: 992px)";
-$mq-lg: "(min-width: 1200px)";
+$mq-xs: "(max-width: 767px)"; // スマホ以下
+$mq-sm: "(min-width: 768px)"; // タブレット以上
+$mq-md: "(min-width: 992px)"; // PC (大き目タブレット)以上
+$mq-lg: "(min-width: 1200px)"; // Full HD以上


### PR DESCRIPTION
Updates the breakpoint for extra small screens to align with common smartphone resolutions.

This ensures a more consistent and responsive user experience across different devices.


解像度の隙間 (Surface Duoの540pxなど)で意図したないレイアウトになっていたので、隙間なくレイアウト設定されるように調整。