### PR TITLE
Fixes: Updates Sass map access and build config

### DIFF
--- a/scss/lib/_core.scss
+++ b/scss/lib/_core.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "sass:map";
 @use "./_variable" as var;
 @use "./_functions" as fn;
 @use "./_table_of_contents";
@@ -45,12 +46,12 @@
     --code-copy-success-bg: #{var.$code-copy-success-bg};
     --code-copy-failed-bg: #{var.$code-copy-failed-bg};
 
-    --codeblock-language-colors-text: #{map-get(var.$codeblock-language-colors, "text")};
-    --codeblock-language-colors-keyword: #{map-get(var.$codeblock-language-colors, "keyword")};
-    --codeblock-language-colors-function: #{map-get(var.$codeblock-language-colors, "function")};
-    --codeblock-language-colors-punctuation: #{map-get(var.$codeblock-language-colors, "punctuation")};
-    --codeblock-language-colors-number: #{map-get(var.$codeblock-language-colors, "number")};
-    --codeblock-language-colors-comment: #{map-get(var.$codeblock-language-colors, "comment")};
+    --codeblock-language-colors-text: #{map.get(var.$codeblock-language-colors, "text")};
+    --codeblock-language-colors-keyword: #{map.get(var.$codeblock-language-colors, "keyword")};
+    --codeblock-language-colors-function: #{map.get(var.$codeblock-language-colors, "function")};
+    --codeblock-language-colors-punctuation: #{map.get(var.$codeblock-language-colors, "punctuation")};
+    --codeblock-language-colors-number: #{map.get(var.$codeblock-language-colors, "number")};
+    --codeblock-language-colors-comment: #{map.get(var.$codeblock-language-colors, "comment")};
 }
 
 html,

--- a/scss/lib/_dark_mode.scss
+++ b/scss/lib/_dark_mode.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "sass:map";
 @use "./_variable" as var;
 @use "./_functions" as fn;
 
@@ -171,12 +172,12 @@ html[data-theme="dark"] {
     --code-copy-success-bg: #{var.$dark-code-copy-success-bg};
     --code-copy-failed-bg: #{var.$dark-code-copy-failed-bg};
 
-    --codeblock-language-colors-text: #{map-get(var.$dark-codeblock-language-colors, "text")};
-    --codeblock-language-colors-keyword: #{map-get(var.$dark-codeblock-language-colors, "keyword")};
-    --codeblock-language-colors-function: #{map-get(var.$dark-codeblock-language-colors, "function")};
-    --codeblock-language-colors-punctuation: #{map-get(var.$dark-codeblock-language-colors, "punctuation")};
-    --codeblock-language-colors-number: #{map-get(var.$dark-codeblock-language-colors, "number")};
-    --codeblock-language-colors-comment: #{map-get(var.$dark-codeblock-language-colors, "comment")};
+    --codeblock-language-colors-text: #{map.get(var.$dark-codeblock-language-colors, "text")};
+    --codeblock-language-colors-keyword: #{map.get(var.$dark-codeblock-language-colors, "keyword")};
+    --codeblock-language-colors-function: #{map.get(var.$dark-codeblock-language-colors, "function")};
+    --codeblock-language-colors-punctuation: #{map.get(var.$dark-codeblock-language-colors, "punctuation")};
+    --codeblock-language-colors-number: #{map.get(var.$dark-codeblock-language-colors, "number")};
+    --codeblock-language-colors-comment: #{map.get(var.$dark-codeblock-language-colors, "comment")};
 }
 
 // システム設定に追従する場合（light/darkの明示指定がない場合）
@@ -223,11 +224,11 @@ html[data-theme="dark"] {
         --code-copy-success-bg: #{var.$dark-code-copy-success-bg};
         --code-copy-failed-bg: #{var.$dark-code-copy-failed-bg};
 
-        --codeblock-language-colors-text: #{map-get(var.$dark-codeblock-language-colors, "text")};
-        --codeblock-language-colors-keyword: #{map-get(var.$dark-codeblock-language-colors, "keyword")};
-        --codeblock-language-colors-function: #{map-get(var.$dark-codeblock-language-colors, "function")};
-        --codeblock-language-colors-punctuation: #{map-get(var.$dark-codeblock-language-colors, "punctuation")};
-        --codeblock-language-colors-number: #{map-get(var.$dark-codeblock-language-colors, "number")};
-        --codeblock-language-colors-comment: #{map-get(var.$dark-codeblock-language-colors, "comment")};
+        --codeblock-language-colors-text: #{map.get(var.$dark-codeblock-language-colors, "text")};
+        --codeblock-language-colors-keyword: #{map.get(var.$dark-codeblock-language-colors, "keyword")};
+        --codeblock-language-colors-function: #{map.get(var.$dark-codeblock-language-colors, "function")};
+        --codeblock-language-colors-punctuation: #{map.get(var.$dark-codeblock-language-colors, "punctuation")};
+        --codeblock-language-colors-number: #{map.get(var.$dark-codeblock-language-colors, "number")};
+        --codeblock-language-colors-comment: #{map.get(var.$dark-codeblock-language-colors, "comment")};
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import autoprefixer from "autoprefixer";
 export default defineConfig({
   build: {
     rollupOptions: {
-      input: ["scss/style.scss", "js/toc-button.js", "js/toc-toggle.js", "js/code-copy.js", "js/tag-cloud.js", "js/dark-mode.js"],
+      input: ["scss/style.scss", "js/toc-button.js", "js/toc-toggle.js", "js/codeblock.js", "js/tag-cloud.js", "js/dark-mode.js"],
       output: {
         assetFileNames: ({ name }) => name,
         entryFileNames: 'js/[name].js',


### PR DESCRIPTION
Updates the way Sass maps are accessed to use the `map.get` syntax, addressing a build error caused by the deprecated `map-get` syntax.

Renames `code-copy.js` to `codeblock.js` in the Vite build configuration to align with its purpose.